### PR TITLE
Fixed `color` property inheritance issue.

### DIFF
--- a/src/ui/backend/BaseBacking.js
+++ b/src/ui/backend/BaseBacking.js
@@ -57,6 +57,7 @@ var BaseBacking = exports = Class(function () {
 		'clip': {value: false},
 		'backgroundColor': {value: ''},
 		'compositeOperation': {value: undefined},
+		'color': {value: ''}
 	};
 
 	this.constructor.addProperty = function (key, def) {


### PR DESCRIPTION
Base `color` property was not inherited correctly because of a missing entry in `BASE_STYLE_PROPS`.
